### PR TITLE
Add RouteServiceUrl field to CFRoute

### DIFF
--- a/cfroutes/routing_info_helpers.go
+++ b/cfroutes/routing_info_helpers.go
@@ -11,8 +11,9 @@ const CF_ROUTER = "cf-router"
 type CFRoutes []CFRoute
 
 type CFRoute struct {
-	Hostnames []string `json:"hostnames"`
-	Port      uint32   `json:"port"`
+	Hostnames       []string `json:"hostnames"`
+	Port            uint32   `json:"port"`
+	RouteServiceUrl string   `json:"route_service_url,omitempty"`
 }
 
 func (c CFRoutes) RoutingInfo() models.Routes {

--- a/cfroutes/routing_info_helpers_test.go
+++ b/cfroutes/routing_info_helpers_test.go
@@ -29,8 +29,9 @@ var _ = Describe("RoutingInfoHelpers", func() {
 			Port:      22222,
 		}
 		route3 = cfroutes.CFRoute{
-			Hostnames: []string{"foo3.example.com", "bar3.examaple.com"},
-			Port:      33333,
+			Hostnames:       []string{"foo3.example.com", "bar3.examaple.com"},
+			Port:            33333,
+			RouteServiceUrl: "rs.example.com",
 		}
 
 		routes = cfroutes.CFRoutes{route1, route2, route3}


### PR DESCRIPTION
This PR adds the new field `RouteServiceUrl` to enable the propagation of route services through Diego and to the GoRouter.

@crhino && @utako